### PR TITLE
Initdb add config option

### DIFF
--- a/config/default.py.dist
+++ b/config/default.py.dist
@@ -8,7 +8,6 @@ DEBUG = False
 # Flask session key
 SECRET_KEY = "secret key"
 
-
 CSRF_ENABLED = True
 CSRF_SESSION_KEY = "your csrf session key"
 
@@ -27,15 +26,15 @@ SITEINFO_DATABASE_HOST = "localhost"
 SITEINFO_DATABASE_USER = ""
 SITEINFO_DATABASE_PASS = ""
 
-# Moodle course install web service definitions
-INSTALL_COURSE_FILE_PATH = "/some/absolute/path/"  # must end with a /
-INSTALL_COURSE_WS_TOKEN = ""
-INSTALL_COURSE_WS_FUNCTION = "local_orvsd_installcourse_install_course"
-
 # google oauth credentials info
 GOOGLE_CLIENT_ID = 'CLIENT ID HERE'
 GOOGLE_CLIENT_SECRET = 'CLIENT SECRET HERE'
 REDIRECT_URI = "/oauth2callback"
+#
+# Moodle course install web service definitions
+INSTALL_COURSE_FILE_PATH = "/some/absolute/path/"  # must end with a /
+INSTALL_COURSE_WS_TOKEN = ""
+INSTALL_COURSE_WS_FUNCTION = "local_orvsd_installcourse_install_course"
 
 # install_course_to_site config info
 # Category is the name according to the moodle site

--- a/config/default.py.dist
+++ b/config/default.py.dist
@@ -22,11 +22,6 @@ CELERY_BROKER_URL = 'sqla+sqlite:///'
 CELERY_RESULT_BACKEND = 'database'
 CELERY_RESULT_DBURI = 'sqlite:///'
 
-# ORVSD Central Admin account credentials
-CENTRAL_ADMIN_USRENAME = ''
-CENTRAL_ADMIN_PASSWORD = ''
-CENTRAL_ADMIN_EMAIL = ''
-
 # database info for data gathering
 SITEINFO_DATABASE_HOST = "localhost"
 SITEINFO_DATABASE_USER = ""

--- a/config/default.py.dist
+++ b/config/default.py.dist
@@ -21,6 +21,11 @@ CELERY_BROKER_URL = 'sqla+sqlite:///'
 CELERY_RESULT_BACKEND = 'database'
 CELERY_RESULT_DBURI = 'sqlite:///'
 
+# ORVSD Central Admin account credentials
+CENTRAL_ADMIN_USRENAME = ''
+CENTRAL_ADMIN_PASSWORD = ''
+CENTRAL_ADMIN_EMAIL = ''
+
 # database info for data gathering
 SITEINFO_DATABASE_HOST = "localhost"
 SITEINFO_DATABASE_USER = ""
@@ -30,7 +35,7 @@ SITEINFO_DATABASE_PASS = ""
 GOOGLE_CLIENT_ID = 'CLIENT ID HERE'
 GOOGLE_CLIENT_SECRET = 'CLIENT SECRET HERE'
 REDIRECT_URI = "/oauth2callback"
-#
+
 # Moodle course install web service definitions
 INSTALL_COURSE_FILE_PATH = "/some/absolute/path/"  # must end with a /
 INSTALL_COURSE_WS_TOKEN = ""

--- a/config/default.py.dist
+++ b/config/default.py.dist
@@ -8,6 +8,7 @@ DEBUG = False
 # Flask session key
 SECRET_KEY = "secret key"
 
+# Flask CSRF
 CSRF_ENABLED = True
 CSRF_SESSION_KEY = "your csrf session key"
 

--- a/manage.py
+++ b/manage.py
@@ -107,7 +107,7 @@ def import_data(data):
 
 
 @manager.command
-def initdb(silent=False):
+def initdb(admin=False, silent=False):
     """
     Sets up the schema for a database that already exists (MySQL, Postgres) or
     creates the database (SQLite3) outright.
@@ -117,7 +117,8 @@ def initdb(silent=False):
     with current_app.app_context():
         g.db_session = create_db_session()
         init_db()
-        create_admin_account(silent)
+        if admin:
+            create_admin_account(silent)
 
 
 @manager.option('-n', '--nosetest', help="Specific tests for nose to run")

--- a/manage.py
+++ b/manage.py
@@ -106,13 +106,8 @@ def import_data(data):
     print "Data imported"
 
 
-@manager.option(
-    '-s',
-    '--from-config',
-    dest='conf',
-    help="Get admin credentials from config rather than waiting on user input"
-)
-def initdb(conf=False):
+@manager.command
+def initdb(silent=False):
     """
     Sets up the schema for a database that already exists (MySQL, Postgres) or
     creates the database (SQLite3) outright.
@@ -122,7 +117,7 @@ def initdb(conf=False):
     with current_app.app_context():
         g.db_session = create_db_session()
         init_db()
-        create_admin_account(conf)
+        create_admin_account(silent)
 
 
 @manager.option('-n', '--nosetest', help="Specific tests for nose to run")

--- a/manage.py
+++ b/manage.py
@@ -8,7 +8,8 @@ from flask.ext.script import Manager
 import nose
 
 from orvsd_central import attach_blueprints, create_app
-from orvsd_central.database import create_db_session, init_db
+from orvsd_central.database import (create_db_session, create_admin_account,
+                                    init_db)
 
 
 def setup_app(config=None):
@@ -105,8 +106,13 @@ def import_data(data):
     print "Data imported"
 
 
-@manager.command
-def initdb():
+@manager.option(
+    '-s',
+    '--from-config',
+    dest='conf',
+    help="Get admin credentials from config rather than waiting on user input"
+)
+def initdb(conf=False):
     """
     Sets up the schema for a database that already exists (MySQL, Postgres) or
     creates the database (SQLite3) outright.
@@ -116,6 +122,7 @@ def initdb():
     with current_app.app_context():
         g.db_session = create_db_session()
         init_db()
+        create_admin_account(conf)
 
 
 @manager.option('-n', '--nosetest', help="Specific tests for nose to run")

--- a/manage.py
+++ b/manage.py
@@ -105,20 +105,29 @@ def import_data(data):
 
     print "Data imported"
 
+@manager.command
+def create_admin(silent=False):
+    """
+    Create an admin account
+
+    -s/--silent: flag to silence user input and instead look for ENVVARs for
+    admin credentials
+    """
+
+    with current_app.app_context():
+        create_admin_account(silent)
+
 
 @manager.command
-def initdb(admin=False, silent=False):
+def initdb():
     """
     Sets up the schema for a database that already exists (MySQL, Postgres) or
     creates the database (SQLite3) outright.
-    * This also includes an option to create a new user, but that won't work
-      on an in-memory database.
     """
+
     with current_app.app_context():
         g.db_session = create_db_session()
         init_db()
-        if admin:
-            create_admin_account(silent)
 
 
 @manager.option('-n', '--nosetest', help="Specific tests for nose to run")

--- a/manage.py
+++ b/manage.py
@@ -57,7 +57,7 @@ def import_data(data):
         schools = csv.reader(csvfile)
         for row in schools:
             dist_state_ids[row[1]] = row[0]
-            district_schools[row[1]].append(row[2:-1])
+            district_schools[row[1]].append(row[2:])
 
     with current_app.app_context():
         # Create a db session

--- a/manage.py
+++ b/manage.py
@@ -115,6 +115,7 @@ def create_admin(silent=False):
     """
 
     with current_app.app_context():
+        g.db_session = create_db_session()
         create_admin_account(silent)
 
 

--- a/orvsd_central/database.py
+++ b/orvsd_central/database.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import current_app, g
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -46,9 +48,9 @@ def create_admin_account(silent):
             if not matching:
                 print "Passwords do not match. Please try again."
     else:
-        username = current_app.config['CENTRAL_ADMIN_USERNAME']
-        password = current_app.config['CENTRAL_ADMIN_PASSWORD']
-        email = current_app.config['CENTRAL_ADMIN_EMAIL']
+        username = os.getenv('CENTRAL_ADMIN_USERNAME', 'admin')
+        password = os.getenv('CENTRAL_ADMIN_PASSWORD', 'admin')
+        email = os.getenv('CENTRAL_ADMIN_EMAIL', 'example@example.com')
 
     # Get admin role.
     from orvsd_central.models import User

--- a/orvsd_central/database.py
+++ b/orvsd_central/database.py
@@ -51,22 +51,30 @@ def create_admin_account(silent):
         email = current_app.config['CENTRAL_ADMIN_EMAIL']
 
     # Get admin role.
-    admin_role = USER_PERMS.get('admin')
-    admin = models.User(
-        name=username,
-        email=email,
-        password=password,
-        role=admin_role
-    )
+    from orvsd_central.models import User
 
-    g.db_session.add(admin)
-    g.db_session.commit()
+    user_exists = g.db_session.query(User).filter(User.name==username)
+    email_exists = g.db_session.query(User).filter(User.email==email)
 
-    print "Administrator account created!"
+    if user_exists:
+        print "Username already in use."
+    elif email_exists:
+        print "Email address already in use."
+    else:
+        admin_role = USER_PERMS.get('admin')
+        admin = User(
+            name=username,
+            email=email,
+            password=password,
+            role=admin_role
+        )
 
-def init_db(admin=False, silent=False):
+        g.db_session.add(admin)
+        g.db_session.commit()
+
+        print "Administrator account created!"
+
+def init_db():
     engine = g.db_session.get_bind()
     from orvsd_central import models
     Model.metadata.create_all(bind=engine)
-    if admin:
-        create_admin_account(silent)

--- a/orvsd_central/database.py
+++ b/orvsd_central/database.py
@@ -22,7 +22,7 @@ def create_db_session():
     return db_session
 
 
-def create_admin_account(config):
+def create_admin_account(silent):
     """
     Create an admin account. This con be done via raw input from the user or
     through config variables
@@ -30,7 +30,7 @@ def create_admin_account(config):
     config: Bool - use config vars
     """
 
-    if not config:
+    if not silent:
         # Create an admin account.
         ans = raw_input("There are currently no admin accounts, would you like to "
                         "create one? (Y/N) ")
@@ -64,7 +64,9 @@ def create_admin_account(config):
 
     print "Administrator account created!"
 
-def init_db():
+def init_db(admin=False, silent=False):
     engine = g.db_session.get_bind()
     from orvsd_central import models
     Model.metadata.create_all(bind=engine)
+    if admin:
+        create_admin_account(silent)


### PR DESCRIPTION
Fixes #66 

Adds the options -a/--admin for adding an admin account and -s/--silent for using config details rather than asking for user input
