### PR TITLE
init_db is now correctly called setup_db in docs

### DIFF
--- a/docs/source/installation_instructions.rst
+++ b/docs/source/installation_instructions.rst
@@ -16,7 +16,7 @@ orvsd_central and run::
 
 \2. Run the following manage.py command before any others::
     
-    python manage.py init_db
+    python manage.py setup_db
 
 A prompt for an admin account creation will show, choose any
 username, email, and password you wish.

--- a/orvsd_central/database.py
+++ b/orvsd_central/database.py
@@ -39,7 +39,7 @@ def create_admin_account(silent):
             admin_count = User.query.filter_by(role=admin_role).count()
         except ProgrammingError:
             # no database
-            print("\nPlease run `manage.py init_db` before adding admins to the database\n")
+            print("\nPlease run `manage.py setup_db` before adding admins to the database\n")
             return
             
         print("There are currently %d admin accounts." % admin_count)


### PR DESCRIPTION
Apparently we call the command setup_db now!
