### PR TITLE
Fix moodle tokens migration

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -149,7 +149,8 @@ def setup_db():
 
         # Query list of existing tables
         tables = con.execute("show tables").fetchall()
-        if 'alembic_version' in tables:
+        alembic_table = ('alembic_version',)
+        if alembic_table in tables:
             # Latest version has been stamped or we have been upgrading
             logging.info("Database: Migrating")
             command.upgrade(alembic_cfg, "head")

--- a/migrations/versions/443742b3e98c_sites_store_multiple_tokens.py
+++ b/migrations/versions/443742b3e98c_sites_store_multiple_tokens.py
@@ -35,7 +35,7 @@ def upgrade_engine1():
     session = Session(bind=op.get_bind())
 
     # Alter the column name
-    op.alter_column('sites', column_name='moodle_token', new_column_name='moodle_tokens')
+    op.alter_column('sites', column_name='api_key', new_column_name='moodle_tokens')
 
     # For each site, convert the field to json, and re-add the token
     # if it had one
@@ -62,7 +62,7 @@ def downgrade_engine1():
     session = Session(bind=op.get_bind())
 
     # Alter the column name
-    op.alter_column('sites', column_name='moodle_tokens', new_column_name='moodle_token')
+    op.alter_column('sites', column_name='moodle_tokens', new_column_name='api_key')
 
     # For each site, get the orvsd_installcourse token, if there is one, and
     # replace the existing data with it, make it an empty string


### PR DESCRIPTION
This migration has been tested on the staging data, whereas before it hadn't been.

This is now more robust, partially executing outside of sqlalchemy mapping to gather the current data then using the mapping to insert the modified data